### PR TITLE
fixing an error for not choosing file for live server

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -135,12 +135,11 @@ public class MessageServlet extends HttpServlet {
     }
 
     // User submitted form without selecting a file, so we can't get a URL. (live server)
-    for(BlobKey blobKey: blobKeys)
-    {
-      BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
-      if (blobInfo.getSize() == 0) {
-        blobstoreService.delete(blobKey);
-      }
+    BlobKey blobKey = blobKeys.get(0);
+    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    if (blobInfo.getSize() == 0) {
+      blobstoreService.delete(blobKey);
+      return null;
     }
 	
     // Use ImagesService to get a URL that points to the uploaded file.


### PR DESCRIPTION
I changed this block of code when I changed the option to add multiple images rather than one image only, but now I realize that the original code that was given to us works in this case. If the user does not select the file (live server version) the code that checks for blobKeys to be null or empty is not enough. Thus, we need the code using blobInfo to check another corner case for live server. I changed this block of code back to the original code that is given to us.